### PR TITLE
Full update for v9

### DIFF
--- a/Dalamud.FullscreenCutscenes/Dalamud.FullscreenCutscenes.csproj
+++ b/Dalamud.FullscreenCutscenes/Dalamud.FullscreenCutscenes.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.10" />
+    <PackageReference Include="DalamudPackager" Version="2.1.12" />
     <Reference Include="FFXIVClientStructs">
       <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
       <Private>false</Private>

--- a/Dalamud.FullscreenCutscenes/Plugin.cs
+++ b/Dalamud.FullscreenCutscenes/Plugin.cs
@@ -4,6 +4,7 @@ using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Game;
 using Dalamud.Hooking;
+using Dalamud.Plugin.Services;
 
 namespace Dalamud.FullscreenCutscenes
 {
@@ -18,13 +19,14 @@ namespace Dalamud.FullscreenCutscenes
         private Hook<UpdateLetterboxingDelegate>? updateLetterboxingHook;
 
         private DalamudPluginInterface PluginInterface { get; init; }
-        private CommandManager CommandManager { get; init; }
+        private ICommandManager CommandManager { get; init; }
         private Configuration Configuration { get; init; }
 
         public Plugin(
             [RequiredVersion("1.0")] DalamudPluginInterface pluginInterface,
-            [RequiredVersion("1.0")] CommandManager commandManager,
-            [RequiredVersion("1.0")] SigScanner targetScanner)
+            [RequiredVersion("1.0")] ICommandManager commandManager,
+            [RequiredVersion("1.0")] ISigScanner targetScanner,
+            [RequiredVersion("1.0")] IGameInteropProvider gameInteropProvider)
         {
             this.PluginInterface = pluginInterface;
             this.CommandManager = commandManager;
@@ -42,7 +44,7 @@ namespace Dalamud.FullscreenCutscenes
 
             if (targetScanner.TryScanText("4C 8B DC 55 48 8B EC", out var ptr))
             {
-                this.updateLetterboxingHook = Hook<UpdateLetterboxingDelegate>.FromAddress(ptr, UpdateLetterboxingDetour);
+                this.updateLetterboxingHook = gameInteropProvider.HookFromAddress<UpdateLetterboxingDelegate>(ptr, UpdateLetterboxingDetour);
                 this.updateLetterboxingHook.Enable();
             }
 

--- a/Dalamud.FullscreenCutscenes/packages.lock.json
+++ b/Dalamud.FullscreenCutscenes/packages.lock.json
@@ -4,9 +4,9 @@
     "net7.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.10, )",
-        "resolved": "2.1.10",
-        "contentHash": "S6NrvvOnLgT4GDdgwuKVJjbFo+8ZEj+JsEYk9ojjOR/MMfv1dIFpT8aRJQfI24rtDcw1uF+GnSSMN4WW1yt7fw=="
+        "requested": "[2.1.12, )",
+        "resolved": "2.1.12",
+        "contentHash": "Sc0PVxvgg4NQjcI8n10/VfUQBAS4O+Fw2pZrAqBdRMbthYGeogzu5+xmIGCGmsEZ/ukMOBuAqiNiB5qA3MRalg=="
       }
     }
   }


### PR DESCRIPTION
* Bump to API9
* Use required interfaces for ICommandManager andISigScanner
* Use IGameInteropProvider instead of old Hook<> functionality.

I have tested this and verified it works as before 6.5. 
