### PR TITLE
1.0.0.3 Update for Dawntrail and API10

### DIFF
--- a/Dalamud.FullscreenCutscenes/Configuration.cs
+++ b/Dalamud.FullscreenCutscenes/Configuration.cs
@@ -14,9 +14,9 @@ namespace Dalamud.FullscreenCutscenes
         // the below exist just to make saving less cumbersome
 
         [NonSerialized]
-        private DalamudPluginInterface? pluginInterface;
+        private IDalamudPluginInterface? pluginInterface;
 
-        public void Initialize(DalamudPluginInterface pluginInterface)
+        public void Initialize(IDalamudPluginInterface pluginInterface)
         {
             this.pluginInterface = pluginInterface;
         }

--- a/Dalamud.FullscreenCutscenes/Dalamud.FullscreenCutscenes.csproj
+++ b/Dalamud.FullscreenCutscenes/Dalamud.FullscreenCutscenes.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>1.0.0.2</Version>
+    <Version>1.0.0.3</Version>
     <Description>A sample plugin.</Description>
     <Copyright></Copyright>
     <PackageProjectUrl>https://github.com/goatcorp/SamplePlugin</PackageProjectUrl>
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <Platforms>x64</Platforms>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.12" />
+    <PackageReference Include="DalamudPackager" Version="2.1.13" />
     <Reference Include="FFXIVClientStructs">
       <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
       <Private>false</Private>

--- a/Dalamud.FullscreenCutscenes/Plugin.cs
+++ b/Dalamud.FullscreenCutscenes/Plugin.cs
@@ -1,6 +1,5 @@
-﻿using System;
+﻿using System.Runtime.InteropServices;
 using Dalamud.Game.Command;
-using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Game;
 using Dalamud.Hooking;
@@ -14,19 +13,18 @@ namespace Dalamud.FullscreenCutscenes
 
         private const string commandName = "/pcutscenes";
 
-        private delegate IntPtr UpdateLetterboxingDelegate(IntPtr thisPtr);
+        private delegate nint UpdateLetterboxingDelegate(nint thisPtr);
 
         private Hook<UpdateLetterboxingDelegate>? updateLetterboxingHook;
 
-        private DalamudPluginInterface PluginInterface { get; init; }
-        private ICommandManager CommandManager { get; init; }
+        private IDalamudPluginInterface PluginInterface { get; init; }
+        private ICommandManager CommandManager { get; init; }   
         private Configuration Configuration { get; init; }
-
         public Plugin(
-            [RequiredVersion("1.0")] DalamudPluginInterface pluginInterface,
-            [RequiredVersion("1.0")] ICommandManager commandManager,
-            [RequiredVersion("1.0")] ISigScanner targetScanner,
-            [RequiredVersion("1.0")] IGameInteropProvider gameInteropProvider)
+             IDalamudPluginInterface pluginInterface,
+             ICommandManager commandManager,
+             ISigScanner targetScanner,
+             IGameInteropProvider gameInteropProvider)
         {
             this.PluginInterface = pluginInterface;
             this.CommandManager = commandManager;
@@ -42,7 +40,7 @@ namespace Dalamud.FullscreenCutscenes
                 HelpMessage = "A useful message to display in /xlhelp"
             });
 
-            if (targetScanner.TryScanText("4C 8B DC 55 48 8B EC", out var ptr))
+            if (targetScanner.TryScanText("E8 ?? ?? ?? ?? 48 8B 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B 8B ?? ?? ?? ??", out var ptr))
             {
                 this.updateLetterboxingHook = gameInteropProvider.HookFromAddress<UpdateLetterboxingDelegate>(ptr, UpdateLetterboxingDetour);
                 this.updateLetterboxingHook.Enable();
@@ -52,10 +50,13 @@ namespace Dalamud.FullscreenCutscenes
             //this.PluginInterface.UiBuilder.OpenConfigUi += DrawConfigUI;
         }
 
-        private IntPtr UpdateLetterboxingDetour(IntPtr thisptr)
+        private unsafe nint UpdateLetterboxingDetour(nint thisptr)
         {
             if (this.Configuration.IsEnabled)
-                return IntPtr.Zero;
+            {
+                SomeConfig* config = (SomeConfig*) thisptr;
+                config->ShouldLetterBox &= ~(1 << 5);
+            }
 
             return this.updateLetterboxingHook!.Original(thisptr);
         }
@@ -78,6 +79,12 @@ namespace Dalamud.FullscreenCutscenes
             }
 
             this.Configuration.Save();
+        }
+        
+        [StructLayout(LayoutKind.Explicit)]
+        public partial struct SomeConfig
+        {
+            [FieldOffset(0x40)] public int ShouldLetterBox;
         }
     }
 }

--- a/Dalamud.FullscreenCutscenes/packages.lock.json
+++ b/Dalamud.FullscreenCutscenes/packages.lock.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
   "dependencies": {
-    "net7.0-windows7.0": {
+    "net8.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.12, )",
-        "resolved": "2.1.12",
-        "contentHash": "Sc0PVxvgg4NQjcI8n10/VfUQBAS4O+Fw2pZrAqBdRMbthYGeogzu5+xmIGCGmsEZ/ukMOBuAqiNiB5qA3MRalg=="
+        "requested": "[2.1.13, )",
+        "resolved": "2.1.13",
+        "contentHash": "rMN1omGe8536f4xLMvx9NwfvpAc9YFFfeXJ1t4P4PE6Gu8WCIoFliR1sh07hM+bfODmesk/dvMbji7vNI+B/pQ=="
       }
     }
   }


### PR DESCRIPTION
Add the required changes for API10 and fixes the plugin for use with 7.0. 
The original function got inlined with it's bigger parent in Dawntrail, thankfully, whatever object this function belongs to, contained a toggle for letterboxing. (Thanks to @notnite for figuring that out).

Seems to behave just like the plugin did prior to 7.0.

(Random sample picture below)
![FINAL FANTASY XIV Online 2024-07-05 22ː04ː11](https://github.com/goaaats/Dalamud.FullscreenCutscenes/assets/8961085/c68eb959-3506-433f-b9cd-de667087ef6b)
